### PR TITLE
Adding LRS Account Service to client.

### DIFF
--- a/src/com/rusticisoftware/hostedengine/client/LrsAccountService.java
+++ b/src/com/rusticisoftware/hostedengine/client/LrsAccountService.java
@@ -1,0 +1,119 @@
+/* Software License Agreement (BSD License)
+ * 
+ * Copyright (c) 2010-2011, Rustici Software, LLC
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Rustici Software, LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.rusticisoftware.hostedengine.client;
+
+import java.util.List;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import com.rusticisoftware.hostedengine.client.datatypes.ActivityProvider;
+
+public class LrsAccountService 
+{
+    private Configuration configuration = null;
+    private ScormEngineService manager = null;
+
+    /// <summary>
+    /// Main constructor that provides necessary configuration information
+    /// </summary>
+    /// <param name="configuration">Application Configuration Data</param>
+    public LrsAccountService(Configuration configuration, ScormEngineService manager)
+    {
+        this.configuration = configuration;
+        this.manager = manager;
+    }
+    
+    /// <summary>
+    /// Calling this method will create a new activity provider with a unique, and randomly generated, key and password combination.
+    /// </summary>
+    /// <returns></returns>
+    public ActivityProvider createActivityProvider() throws Exception
+    {
+        ServiceRequest sr = new ServiceRequest(this.configuration);
+
+        Document response = sr.callService("rustici.lrsaccount.createActivityProvider");
+        Element resultElem = (Element)(response.getElementsByTagName("activityProvider").item(0));
+        return ActivityProvider.parseFromXmlElement(resultElem);
+    }
+
+    /// <summary>
+    /// Calling this method will return a list of all current activity providers created by this service.
+    /// </summary>
+    /// <returns></returns>
+    public List<ActivityProvider> listActivityProviders() throws Exception
+    {
+      ServiceRequest sr = new ServiceRequest(this.configuration);
+      Document response = sr.callService("rustici.lrsaccount.listActivityProviders");
+
+      return ActivityProvider.parseListFromXml(response);
+    }
+
+    /// <summary>
+    /// A call to this method with the optional parameters passed to it will modify those values for the activity provider 
+    /// indicated by the accountKey.
+    /// </summary>
+    /// <param name="accountKey">Required account key for the activity provider to modify</param>
+    /// <param name="authType">Optional 'basic' or 'oauth'</param>
+    /// <param name="isActive">Optional true or false indicating whether or not this account should be enabled</param>
+    /// <param name="label">Optional name for the activity provider</param>
+    public void editActivityProvider(String accountKey, String authType, Boolean isActive, String label) throws Exception 
+    {
+      ServiceRequest sr = new ServiceRequest(configuration);
+
+      sr.getParameters().add("accountkey", accountKey);
+
+      if(authType != null) {
+        sr.getParameters().add("authtype", authType);
+      }
+      if(isActive != null) {
+        sr.getParameters().add("isactive", isActive);
+      }
+      if(label != null) {
+        sr.getParameters().add("label", label);
+      }
+
+      sr.callService("rustici.lrsaccount.editActivityProvider");
+    }
+    
+    /// <summary>
+    /// Calling this method deletes the activity provider indicated by the accountKey passed in. This cannot be undone. If you 
+    /// wish to temporarily disable an Activity provider use the edit API instead.
+    /// </summary>
+    /// <param name="accountKey">Required account key for the activity provider to delete</param>
+    public void deleteActivityProvider(String accountKey) throws Exception
+    {
+        ServiceRequest sr = new ServiceRequest(configuration);
+        
+        sr.getParameters().add("accountkey", accountKey);
+        
+        sr.callService("rustici.lrsaccount.deleteActivityProvider");
+    }
+
+}

--- a/src/com/rusticisoftware/hostedengine/client/ScormEngineService.java
+++ b/src/com/rusticisoftware/hostedengine/client/ScormEngineService.java
@@ -31,6 +31,7 @@ package com.rusticisoftware.hostedengine.client;
 public class ScormEngineService
 {
     private Configuration configuration = null;
+    private LrsAccountService lrsAccountService = null;
     private CourseService courseService = null;
     private RegistrationService registrationService = null;
     private UploadService uploadService = null;
@@ -62,6 +63,7 @@ public class ScormEngineService
     public ScormEngineService(Configuration config)
     {
         configuration = config;
+        lrsAccountService = new LrsAccountService(configuration, this);
         courseService = new CourseService(configuration, this);
         registrationService = new RegistrationService(configuration, this);
         invitationService = new InvitationService(configuration, this);
@@ -73,6 +75,14 @@ public class ScormEngineService
         dispatchService = new DispatchService(configuration, this);
         debugService = new DebugService(configuration, this);
         stmtFrwdService = new StatementForwardService(configuration, this);
+    }
+    
+    /// <summary>
+    /// Contains SCORM Engine LRS account functionality.
+    /// </summary>
+    public LrsAccountService getAccountService()
+    {
+        return lrsAccountService;
     }
 
     /// <summary>

--- a/src/com/rusticisoftware/hostedengine/client/datatypes/ActivityProvider.java
+++ b/src/com/rusticisoftware/hostedengine/client/datatypes/ActivityProvider.java
@@ -1,0 +1,156 @@
+/* Software License Agreement (BSD License)
+ * 
+ * Copyright (c) 2010-2011, Rustici Software, LLC
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Rustici Software, LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.rusticisoftware.hostedengine.client.datatypes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import com.rusticisoftware.hostedengine.client.XmlUtils;
+
+public class ActivityProvider
+{
+    private Boolean accountEnabled;
+
+    private String accountAuthType;
+    private String accountKey;
+    private String accountLabel;
+    private String accountSecret;
+    private String id;
+    
+
+    public static ActivityProvider parseFromXmlElement(Element exportElem) throws Exception {
+      ActivityProvider provider = new ActivityProvider();
+
+      String enabledStr = XmlUtils.getChildElemText(exportElem, "accountEnabled");
+      provider.setAccountEnabled("true".equals(enabledStr));
+
+      provider.setAccountAuthType(XmlUtils.getChildElemText(exportElem, "accountAuthType"));
+      provider.setAccountKey(XmlUtils.getChildElemText(exportElem, "accountKey"));
+      provider.setAccountLabel(XmlUtils.getChildElemText(exportElem, "accountLabel"));
+      provider.setAccountSecret(XmlUtils.getChildElemText(exportElem, "accountSecret"));
+      provider.setId(XmlUtils.getChildElemText(exportElem, "id"));
+
+      return provider;
+    }
+
+    public static List<ActivityProvider> parseListFromXml (Document courseListXmlDoc) throws Exception {
+      Element activityProviderListElem = (Element)courseListXmlDoc.getElementsByTagName("activityProviderList").item(0);
+
+      List<ActivityProvider> providerList = new ArrayList<ActivityProvider>();
+
+      NodeList providerElems = activityProviderListElem.getChildNodes();
+      for(int i = 0; i < providerElems.getLength(); i++){
+        if(providerElems.item(i) instanceof Element) {
+        } else {
+          continue;
+        }
+        Element courseElem = (Element)providerElems.item(i);
+        providerList.add( parseFromXmlElement(courseElem) );
+      }
+
+      return providerList;
+    }
+
+    public static String getXmlString (List<ActivityProvider> actiivtyProviderList){
+      StringBuilder xml = new StringBuilder();
+      xml.append("<activityProviderList>\n");
+      for(ActivityProvider data : actiivtyProviderList){
+        xml.append(data.getXmlString());
+      }
+      xml.append("</activityProviderList>");
+      return xml.toString();
+    }
+
+    public String getXmlString() {
+      StringBuilder xml = new StringBuilder();
+      xml.append("  <activityProvider>\n");
+      xml.append("    <id><![CDATA[" + getId() + "]]></id>\n");
+      xml.append("    <accountLabel><![CDATA[" + getAccountLabel() + "]]></accountLabel>\n");
+      xml.append("    <accountKey><![CDATA[" + getAccountKey() + "]]></accountKey>\n");
+      xml.append("    <accountSecret><![CDATA[" + getAccountSecret() + "]]></accountSecret>\n");
+      xml.append("    <accountAuthType><![CDATA[" + getAccountAuthType() + "]]></accountAuthType>\n");
+      xml.append("    <accountEnabled>" + getAccountEnabled() + "</accountEnabled>\n");
+      xml.append("  </activityProvider>\n");
+
+      return xml.toString();
+    }
+
+    public Boolean getAccountEnabled() {
+      return accountEnabled;
+    }
+
+    public void setAccountEnabled(Boolean accountEnabled) {
+      this.accountEnabled = accountEnabled;
+    }
+
+    public String getAccountAuthType() {
+      return accountAuthType;
+    }
+
+    public void setAccountAuthType(String accountAuthType) {
+      this.accountAuthType = accountAuthType;
+    }
+
+    public String getAccountKey() {
+      return accountKey;
+    }
+
+    public void setAccountKey(String accountKey) {
+      this.accountKey = accountKey;
+    }
+
+    public String getAccountLabel() {
+      return accountLabel;
+    }
+
+    public void setAccountLabel(String accountLabel) {
+      this.accountLabel = accountLabel;
+    }
+
+    public String getAccountSecret() {
+      return accountSecret;
+    }
+
+    public void setAccountSecret(String accountSecret) {
+      this.accountSecret = accountSecret;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+}


### PR DESCRIPTION
I've written this client implementation for the missing LRS Account Service in the style of the other services in this project.  I think it would be cleaner like this, right inside the client library instead of hidden away in some separate external code that I originally wrote.

Would you have any interest in merging this in?  I'd be happy to change anything up to conform to any coding styles that I might have missed or anything else.

Thanks for looking,

Jeremy