### PR TITLE
Use long instead of int for request length when posting files

### DIFF
--- a/src/com/rusticisoftware/hostedengine/client/ServiceRequest.java
+++ b/src/com/rusticisoftware/hostedengine/client/ServiceRequest.java
@@ -441,7 +441,7 @@ public class ServiceRequest {
 
 		final String introStr = intro.toString();
 		final String outroStr = outro.toString();
-		int requestLength = introStr.getBytes("utf8").length + (int)(file.length()) + outroStr.getBytes("utf8").length;
+		long requestLength = introStr.getBytes("utf8").length + file.length() + outroStr.getBytes("utf8").length;
 
 		connection.setDoOutput(true);
 		connection.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);


### PR DESCRIPTION
Downcasting file.length() to an int causes problems when files are
larger than about 2.1 GiB. This commit maintains the original long
instead of downcasting, which should fix this problem.

This bug leads to an IOException when uploading large files.