### PR TITLE
Fix Java 7 compatibility, update README to match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .settings/
 bin/
 META-INF/
+target/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See our [API quick start][1] guide for more information.
 
 ## Requirements
 
-Requires Java 6 or greater.
+Requires Java 7 or greater.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ In a Maven configuration,
     <dependency>
        <groupId>com.rusticisoftware.hostedengine.client</groupId>
        <artifactId>scormcloud-java-lib</artifactId>
-       <version>1.1.2</version>
+       <version>1.1.3</version>
     </dependency>
 
 or in Gradle:
 
-    compile 'com.rusticisoftware.hostedengine.client:scormcloud-java-lib:1.1.2'
+    compile 'com.rusticisoftware.hostedengine.client:scormcloud-java-lib:1.1.3'
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,32 @@ Don't hesitate to submit technical questions. Our support staff are excellent,
 and even if they can't answer a question or resolve a problem, tickets get
 escalated quickly to real, live developers.
 
+## Building Client Library
+
+Note: This section is for developing the client library itself and can be
+ignored if you're just interested in using it.
+
+This client library uses Maven to build.
+
+    mvn package
+
+will build jars and place them in `target/`.
+
+To check Java compatibility, run:
+
+    mvn animal-sniffer:check
+
+Java compatibility is controlled by the `maven.compiler.source` and
+`maven.compiler.target` parameters. To make the Animal Sniffer plugin
+check our API usage against a different version of Java, edit
+
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java17</artifactId>
+            <version>1.0</version>
+          </signature>
+
+in the pom.xml (e.g., change `java17` to `java16` to test Java 6 compat.)
 
 [1]: https://cloud.scorm.com/docs/quick_start.html
 [2]: http://mvnrepository.com/artifact/com.rusticisoftware.hostedengine.client/scormcloud-java-lib

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,18 @@
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.16</version>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java17</artifactId>
+            <version>1.0</version>
+          </signature>
+        </configuration>
+      </plugin>
     </plugins>
 
     <sourceDirectory>${basedir}/src</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   </scm>
 
   <packaging>jar</packaging>
-  <version>1.1.2</version>
+  <version>1.1.3</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -2,16 +2,16 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<name>SCORM Cloud Java Library</name>
+  <modelVersion>4.0.0</modelVersion>
+  <name>SCORM Cloud Java Library</name>
   <description>Client Library for SCORM Cloud API.</description>
   <url>https://scorm.com/scorm-solved/scorm-cloud-developers/how-to-get-started-with-the-scorm-cloud-api/</url>
-	<groupId>com.rusticisoftware.hostedengine.client</groupId>
-	<artifactId>scormcloud-java-lib</artifactId>
-	<organization>
-		<name>Rustici Software</name>
-		<url>http://scorm.com</url>
-	</organization>
+  <groupId>com.rusticisoftware.hostedengine.client</groupId>
+  <artifactId>scormcloud-java-lib</artifactId>
+  <organization>
+    <name>Rustici Software</name>
+    <url>http://scorm.com</url>
+  </organization>
 
   <licenses>
     <license>
@@ -36,71 +36,71 @@
   </scm>
 
   <packaging>jar</packaging>
-	<version>1.1.2</version>
+  <version>1.1.2</version>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-	</properties>
+  </properties>
 
-	<build>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-source-plugin</artifactId>
-          <version>2.2.1</version>
-          <executions>
-            <execution>
-              <id>attach-sources</id>
-              <goals>
-                <goal>jar-no-fork</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9.1</version>
-          <executions>
-            <execution>
-              <id>attach-javadocs</id>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-gpg-plugin</artifactId>
-          <version>1.5</version>
-          <executions>
-            <execution>
-              <id>sign-artifacts</id>
-              <phase>verify</phase>
-              <goals>
-                <goal>sign</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.7</version>
-          <extensions>true</extensions>
-          <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-          </configuration>
-        </plugin>
-      </plugins>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+    </plugins>
 
-      <sourceDirectory>${basedir}/src</sourceDirectory>
-	</build>
+    <sourceDirectory>${basedir}/src</sourceDirectory>
+  </build>
 
   <distributionManagement>
     <snapshotRepository>


### PR DESCRIPTION
Fixes ZD-39638.

Bumps version to 1.1.3 in preparation for Maven publish.

Note: Java 6 support isn't available since we use the `long` version of [setFixedLengthStreamingMode](https://docs.oracle.com/javase/7/docs/api/java/net/HttpURLConnection.html#setFixedLengthStreamingMode(long)), which is necessary to support courses greater than 2 GiB in size, which isn't available in Java 6.